### PR TITLE
feat/hybrid search: add hybrid search and keyword search support

### DIFF
--- a/rag/config/settings.py
+++ b/rag/config/settings.py
@@ -33,6 +33,11 @@ EMBEDDING_MAX_TOKENS = int(os.getenv("EMBEDDING_MAX_TOKENS", "8191"))
 TOP_K_RESULTS = int(os.getenv("TOP_K_RESULTS", "5"))
 SIMILARITY_THRESHOLD = float(os.getenv("SIMILARITY_THRESHOLD", "0.3"))
 
+# Hybrid search configuration
+HYBRID_SEARCH_ALPHA = float(os.getenv("HYBRID_SEARCH_ALPHA", "0.6"))
+KEYWORD_SEARCH_ENABLED = os.getenv("KEYWORD_SEARCH_ENABLED", "true").lower() == "true"
+HYBRID_SEARCH_K_MULTIPLIER = int(os.getenv("HYBRID_SEARCH_K_MULTIPLIER", "3"))
+
 # RAG generation configuration
 TEMPERATURE = float(os.getenv("TEMPERATURE", "0.7"))
 MAX_OUTPUT_TOKENS = int(os.getenv("MAX_OUTPUT_TOKENS", "1000"))

--- a/rag/config/settings.py
+++ b/rag/config/settings.py
@@ -36,7 +36,6 @@ SIMILARITY_THRESHOLD = float(os.getenv("SIMILARITY_THRESHOLD", "0.3"))
 # Hybrid search configuration
 HYBRID_SEARCH_ALPHA = float(os.getenv("HYBRID_SEARCH_ALPHA", "0.6"))
 KEYWORD_SEARCH_ENABLED = os.getenv("KEYWORD_SEARCH_ENABLED", "true").lower() == "true"
-HYBRID_SEARCH_K_MULTIPLIER = int(os.getenv("HYBRID_SEARCH_K_MULTIPLIER", "3"))
 
 # RAG generation configuration
 TEMPERATURE = float(os.getenv("TEMPERATURE", "0.7"))

--- a/rag/core/vector_store.py
+++ b/rag/core/vector_store.py
@@ -159,10 +159,15 @@ class VectorStore:
                 query = base_query + sql.SQL(" ORDER BY c.embedding <#> %s::vector LIMIT %s")
                 result = cur.execute(query, (query_embedding, query_embedding, k))
 
-            results = result.fetchall()
+            # Extract results (rows) as dicts
+            results = [dict(r) for r in result.fetchall()]
 
-            # Format results
-            return [dict(result) for result in results]
+            # Merge doc_metadata into metadata for easier access, remove doc_metadata
+            for row in results:
+                row["metadata"] = (row.get("metadata") or {}) | (row.get("doc_metadata") or {})
+                row.pop("doc_metadata", None)
+
+            return results
 
     def keyword_search(self, query: str, k: int = 5) -> list[dict[str, Any]]:
         """
@@ -195,10 +200,16 @@ class VectorStore:
             """).format(sql.Identifier(self.schema), sql.Identifier(self.schema))
 
             result = cur.execute(query_sql, (query, query, query, k))
-            results = result.fetchall()
 
-            # Format results
-            return [dict(result) for result in results]
+            # Extract results (rows) as dicts
+            results = [dict(r) for r in result.fetchall()]
+
+            # Merge doc_metadata into metadata for easier access, remove doc_metadata
+            for row in results:
+                row["metadata"] = (row.get("metadata") or {}) | (row.get("doc_metadata") or {})
+                row.pop("doc_metadata", None)
+
+            return results
 
     def get_document_count(self) -> int:
         """Get the total number of documents in the store."""

--- a/rag/core/vector_store.py
+++ b/rag/core/vector_store.py
@@ -11,6 +11,7 @@ from psycopg.rows import dict_row
 from rag.config.settings import (
     EMBEDDING_DIMENSIONS,
     EMBEDDING_MAX_TOKENS,
+    KEYWORD_SEARCH_ENABLED,
     SCHEMA_NAME,
     get_psycopg_connection_string,
 )
@@ -161,19 +162,43 @@ class VectorStore:
             results = result.fetchall()
 
             # Format results
-            return [
-                {
-                    "id": r["id"],
-                    "content": r["content"],
-                    "chunk_index": r["chunk_index"],
-                    "metadata": {**r["metadata"], **(r["doc_metadata"] or {})},
-                    "title": r["title"],
-                    "source": r["source"],
-                    "similarity": float(r["similarity"]),
-                    "created_at": r["created_at"].isoformat() if r["created_at"] else None,
-                }
-                for r in results
-            ]
+            return [dict(result) for result in results]
+
+    def keyword_search(self, query: str, k: int = 5) -> list[dict[str, Any]]:
+        """
+        Perform keyword search using PostgreSQL full-text search.
+
+        Args:
+            query: Search query text
+            k: Number of results to return
+
+        Returns:
+            List of matching chunks with metadata and text search rank
+        """
+        with self.conn.cursor(row_factory=dict_row) as cur:
+            query_sql = sql.SQL("""
+                SELECT
+                    c.id,
+                    c.content,
+                    c.chunk_index,
+                    c.metadata,
+                    d.title,
+                    d.source,
+                    d.metadata as doc_metadata,
+                    ts_rank(c.fts, plainto_tsquery('english', %s)) as rank,
+                    c.created_at
+                FROM {}.chunks c
+                JOIN {}.documents d ON c.document_id = d.id
+                WHERE c.fts @@ plainto_tsquery('english', %s)
+                ORDER BY ts_rank(c.fts, plainto_tsquery('english', %s)) DESC
+                LIMIT %s
+            """).format(sql.Identifier(self.schema), sql.Identifier(self.schema))
+
+            result = cur.execute(query_sql, (query, query, query, k))
+            results = result.fetchall()
+
+            # Format results
+            return [dict(result) for result in results]
 
     def get_document_count(self) -> int:
         """Get the total number of documents in the store."""
@@ -208,6 +233,7 @@ class VectorStore:
             "total_chunks": self.get_chunk_count(),
             "embedding_dimensions": EMBEDDING_DIMENSIONS,
             "embedding_max_tokens": EMBEDDING_MAX_TOKENS,
+            "keyword_search_enabled": KEYWORD_SEARCH_ENABLED,
         }
 
     def close(self):

--- a/rag/rag_system.py
+++ b/rag/rag_system.py
@@ -3,12 +3,7 @@
 import warnings
 from typing import Any
 
-from rag.config.settings import (
-    HYBRID_SEARCH_ALPHA,
-    HYBRID_SEARCH_K_MULTIPLIER,
-    SIMILARITY_THRESHOLD,
-    TOP_K_RESULTS,
-)
+from rag.config.settings import HYBRID_SEARCH_ALPHA, SIMILARITY_THRESHOLD, TOP_K_RESULTS
 from rag.core.document_processor import DocumentProcessor
 from rag.core.embedding_service import EmbeddingService
 from rag.core.llm_service import LLMService
@@ -169,6 +164,7 @@ class RAGSystem:
             **vector_stats,
             "embedding_model": self.embedding_service.model,
             "embedding_dimensions": self.embedding_service.dimensions,
+            "cached_queries": len(self._query_embedding_cache),
             **generation_stats,
         }
 
@@ -241,7 +237,7 @@ class RAGSystem:
         print(f"Performing hybrid search (α={alpha:.1f})...")
 
         # Get more results from each method for better fusion
-        search_k = k * HYBRID_SEARCH_K_MULTIPLIER
+        search_k = k * 3
 
         # Semantic search
         semantic_results = self.vector_store.similarity_search(


### PR DESCRIPTION
This PR introduces hybrid search capabilities using Reciprocal Rank Fusion (RRF), adds PostgreSQL full-text keyword search with English stemming, and enhances the query() method for configurable search modes.

- Implement keyword_search() with PostgreSQL full-text search (English stemming, GIN index).
- Add similarity_search(), keyword_search(), and hybrid_search() with RRF fusion.
- Enhance query() with search_mode/alpha params, input validation, and consistent return format.
- Merge document and chunk metadata into a single metadata field and standardize result formatting.
- Update config with HYBRID_SEARCH_ALPHA and KEYWORD_SEARCH_ENABLED flags.

Note: The Vector store manages all database operations, while the hybrid search logic resides in RAGSystem.