### PR TITLE
refactor(rag): migrate to centralized, type-safe Pydantic settings

### DIFF
--- a/rag/config/settings.py
+++ b/rag/config/settings.py
@@ -1,57 +1,73 @@
 """Configuration settings for the RAG pipeline."""
 
-import os
-from typing import Any
+from functools import lru_cache
 
-from dotenv import load_dotenv
+from pydantic import Field, SecretStr
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
-# Load environment variables
-load_dotenv()
 
-# Database configuration for PostgreSQL with pgvector
-DATABASE_CONFIG: dict[str, Any] = {
-    "host": os.getenv("DB_HOST", "localhost"),
-    "port": int(os.getenv("DB_PORT", "5432")),
-    "database": os.getenv("DB_NAME", "vectordb"),
-    "user": os.getenv("DB_USER", "postgres"),
-    "password": os.getenv("DB_PASSWORD", "postgres"),
-}
+class DatabaseConfig(BaseSettings):
+    """Database configuration for PostgreSQL with pgvector."""
 
-# OpenAI configuration
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-if not OPENAI_API_KEY:
-    raise ValueError("OPENAI_API_KEY environment variable is required")
+    # Database connection
+    host: str = Field(alias="DB_HOST", default="localhost")
+    port: int = Field(alias="DB_PORT", default=5432)
+    name: str = Field(alias="DB_NAME", default="vectordb")
+    user: str = Field(alias="DB_USER", default="postgres")
+    password: str = Field(alias="DB_PASSWORD", default="postgres")
 
-EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "text-embedding-3-small")
-EMBEDDING_DIMENSIONS = int(os.getenv("EMBEDDING_DIMENSIONS", "1536"))
-CHAT_MODEL = os.getenv("CHAT_MODEL", "gpt-4o-mini")
+    # Database schema
+    schema_name: str = Field(alias="SCHEMA_NAME", default="rag")
 
-# Document processing configuration
-EMBEDDING_MAX_TOKENS = int(os.getenv("EMBEDDING_MAX_TOKENS", "8191"))
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore", case_sensitive=False)
 
-# Vector search configuration
-TOP_K_RESULTS = int(os.getenv("TOP_K_RESULTS", "5"))
-SEMANTIC_THRESHOLD = float(os.getenv("SEMANTIC_THRESHOLD", "0.3"))
+    @property
+    def conn_string(self) -> str:
+        """Build psycopg3 connection string."""
+        return (
+            f"host={self.host} "
+            f"port={self.port} "
+            f"dbname={self.name} "
+            f"user={self.user} "
+            f"password={self.password}"
+        )
 
-# Hybrid search configuration
-HYBRID_SEARCH_ALPHA = float(os.getenv("HYBRID_SEARCH_ALPHA", "0.6"))
-KEYWORD_SEARCH_ENABLED = os.getenv("KEYWORD_SEARCH_ENABLED", "true").lower() == "true"
 
-# RAG generation configuration
-TEMPERATURE = float(os.getenv("TEMPERATURE", "0.7"))
-MAX_OUTPUT_TOKENS = int(os.getenv("MAX_OUTPUT_TOKENS", "1000"))
+class Settings(BaseSettings):
+    """Main RAG pipeline configuration."""
 
-# Database schema configuration
-SCHEMA_NAME = os.getenv("SCHEMA_NAME", "rag")
+    # Database
+    database: DatabaseConfig = Field(default_factory=DatabaseConfig)
+
+    # OpenAI configuration
+    openai_api_key: SecretStr = Field(alias="OPENAI_API_KEY")
+    embedding_model: str = Field(default="text-embedding-3-small", alias="EMBEDDING_MODEL")
+    embedding_dimensions: int = Field(default=1536, alias="EMBEDDING_DIMENSIONS")
+    chat_model: str = Field(default="gpt-4o-mini", alias="CHAT_MODEL")
+    temperature: float = Field(default=0.7, alias="TEMPERATURE")
+    max_output_tokens: int = Field(default=1000, alias="MAX_OUTPUT_TOKENS")
+    embedding_max_tokens: int = Field(default=8191, alias="EMBEDDING_MAX_TOKENS")
+
+    # Vector search
+    top_k_results: int = Field(default=5, alias="TOP_K_RESULTS")
+    semantic_threshold: float = Field(default=0.3, alias="SEMANTIC_THRESHOLD")
+
+    # Hybrid search
+    hybrid_search_alpha: float = Field(default=0.6, alias="HYBRID_SEARCH_ALPHA")
+    keyword_search_enabled: bool = Field(default=True, alias="KEYWORD_SEARCH_ENABLED")
+
+    # Logging
+    log_level: str = Field(default="INFO", alias="LOG_LEVEL")
+
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Get cached settings instance (singleton)."""
+    return Settings()
 
 
 def get_psycopg_connection_string() -> str:
     """Build psycopg3 connection string."""
-    config = DATABASE_CONFIG
-    return (
-        f"host={config['host']} "
-        f"port={config['port']} "
-        f"dbname={config['database']} "
-        f"user={config['user']} "
-        f"password={config['password']}"
-    )
+    return get_settings().database.conn_string

--- a/rag/core/document_processor.py
+++ b/rag/core/document_processor.py
@@ -7,7 +7,7 @@ from docling.document_converter import DocumentConverter
 from docling_core.transforms.chunker.hybrid_chunker import HybridChunker
 from docling_core.transforms.chunker.tokenizer.openai import OpenAITokenizer
 
-from rag.config.settings import EMBEDDING_MAX_TOKENS, EMBEDDING_MODEL
+from rag.config.settings import get_settings
 
 
 class DocumentProcessor:
@@ -16,9 +16,10 @@ class DocumentProcessor:
     def __init__(self):
         """Initialize the document processor with tokenizer and chunker."""
         # Set up tokenizer for chunking
-        tiktoken_encoder = tiktoken.encoding_for_model(EMBEDDING_MODEL)  # cl100k_base
+        settings = get_settings()
+        tiktoken_encoder = tiktoken.encoding_for_model(settings.embedding_model)  # cl100k_base
         self.tokenizer = OpenAITokenizer(
-            tokenizer=tiktoken_encoder, max_tokens=EMBEDDING_MAX_TOKENS
+            tokenizer=tiktoken_encoder, max_tokens=settings.embedding_max_tokens
         )
         self.chunker = HybridChunker(tokenizer=self.tokenizer)
         self.converter = DocumentConverter()

--- a/rag/core/embedding_service.py
+++ b/rag/core/embedding_service.py
@@ -5,7 +5,7 @@ from typing import Any
 from openai import OpenAI
 from tqdm import tqdm
 
-from rag.config.settings import EMBEDDING_DIMENSIONS, EMBEDDING_MODEL, OPENAI_API_KEY
+from rag.config.settings import get_settings
 
 
 class EmbeddingService:
@@ -13,9 +13,10 @@ class EmbeddingService:
 
     def __init__(self):
         """Initialize the embedding service with OpenAI client."""
-        self.client = OpenAI(api_key=OPENAI_API_KEY)
-        self.model = EMBEDDING_MODEL
-        self.dimensions = EMBEDDING_DIMENSIONS
+        settings = get_settings()
+        self.client = OpenAI(api_key=settings.openai_api_key.get_secret_value())
+        self.model = settings.embedding_model
+        self.dimensions = settings.embedding_dimensions
 
     def create_embedding(self, text: str) -> list[float]:
         """

--- a/rag/core/llm_service.py
+++ b/rag/core/llm_service.py
@@ -4,12 +4,7 @@ from typing import Any
 
 from openai import OpenAI
 
-from rag.config.settings import (
-    CHAT_MODEL,
-    MAX_OUTPUT_TOKENS,
-    OPENAI_API_KEY,
-    TEMPERATURE,
-)
+from rag.config.settings import get_settings
 
 
 class LLMService:
@@ -17,10 +12,11 @@ class LLMService:
 
     def __init__(self):
         """Initialize the LLM service with OpenAI client."""
-        self.client = OpenAI(api_key=OPENAI_API_KEY)
-        self.model = CHAT_MODEL
-        self.temperature = TEMPERATURE
-        self.max_output_tokens = MAX_OUTPUT_TOKENS
+        settings = get_settings()
+        self.client = OpenAI(api_key=settings.openai_api_key.get_secret_value())
+        self.model = settings.chat_model
+        self.temperature = settings.temperature
+        self.max_output_tokens = settings.max_output_tokens
 
     def generate_response(self, messages: list[dict[str, str]]) -> str:
         """

--- a/rag/core/vector_store.py
+++ b/rag/core/vector_store.py
@@ -8,13 +8,7 @@ from pgvector.psycopg import register_vector
 from psycopg import sql
 from psycopg.rows import dict_row
 
-from rag.config.settings import (
-    EMBEDDING_DIMENSIONS,
-    EMBEDDING_MAX_TOKENS,
-    KEYWORD_SEARCH_ENABLED,
-    SCHEMA_NAME,
-    get_psycopg_connection_string,
-)
+from rag.config.settings import get_settings
 
 
 class VectorStore:
@@ -22,13 +16,15 @@ class VectorStore:
 
     def __init__(self):
         """Initialize vector store with database connection."""
-        self.schema = SCHEMA_NAME
+        settings = get_settings()
+        self.schema = settings.database.schema_name
         self.conn: psycopg.Connection = self._establish_connection()
 
     def _establish_connection(self) -> psycopg.Connection:
         """Establish connection to PostgreSQL database."""
         try:
-            conn_str = get_psycopg_connection_string()
+            settings = get_settings()
+            conn_str = settings.database.conn_string
             conn = psycopg.connect(conn_str)
             conn.execute("CREATE EXTENSION IF NOT EXISTS vector")
             register_vector(conn)
@@ -239,12 +235,13 @@ class VectorStore:
 
     def get_stats(self) -> dict[str, Any]:
         """Get database statistics."""
+        settings = get_settings()
         return {
             "total_documents": self.get_document_count(),
             "total_chunks": self.get_chunk_count(),
-            "embedding_dimensions": EMBEDDING_DIMENSIONS,
-            "embedding_max_tokens": EMBEDDING_MAX_TOKENS,
-            "keyword_search_enabled": KEYWORD_SEARCH_ENABLED,
+            "embedding_dimensions": settings.embedding_dimensions,
+            "embedding_max_tokens": settings.embedding_max_tokens,
+            "keyword_search_enabled": settings.keyword_search_enabled,
         }
 
     def close(self):

--- a/rag/rag_system.py
+++ b/rag/rag_system.py
@@ -3,7 +3,7 @@
 import warnings
 from typing import Any
 
-from rag.config.settings import HYBRID_SEARCH_ALPHA, SEMANTIC_THRESHOLD, TOP_K_RESULTS
+from rag.config.settings import get_settings
 from rag.core.document_processor import DocumentProcessor
 from rag.core.embedding_service import EmbeddingService
 from rag.core.llm_service import LLMService
@@ -105,10 +105,10 @@ class RAGSystem:
     def query(
         self,
         question: str,
-        k: int = TOP_K_RESULTS,
-        threshold: float = SEMANTIC_THRESHOLD,
+        k: int | None = None,
+        threshold: float | None = None,
         search_mode: str = "semantic",
-        alpha: float = HYBRID_SEARCH_ALPHA,
+        alpha: float | None = None,
     ) -> dict[str, Any]:
         """
         Main query method that combines retrieval and generation.
@@ -126,6 +126,12 @@ class RAGSystem:
         Raises:
             ValueError: If search_mode is not one of the supported modes
         """
+        # Set defaults from settings if not provided
+        settings = get_settings()
+        k = k or settings.top_k_results
+        threshold = threshold or settings.semantic_threshold
+        alpha = alpha or settings.hybrid_search_alpha
+
         logger.debug(f"Processing query with {search_mode} search: {question}")
 
         # Route to appropriate search method based on search_mode

--- a/rag/utils/logger.py
+++ b/rag/utils/logger.py
@@ -4,10 +4,11 @@ Single instance, environment-configurable, suppresses noisy libraries.
 """
 
 import logging
-import os
 import sys
 import time
 from functools import lru_cache
+
+from rag.config.settings import get_settings
 
 
 @lru_cache
@@ -19,8 +20,9 @@ def setup_logger() -> logging.Logger:
     # Configure timestamp to UTC
     logging.Formatter.converter = time.gmtime
 
-    # Get environment configuration
-    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    # Get configuration from settings
+    settings = get_settings()
+    log_level = settings.log_level.upper()
 
     # Create main logger
     logger = logging.getLogger("rag")


### PR DESCRIPTION
This PR migrates the RAG system from environment variable-based configuration to a centralized, type-safe Pydantic settings system. This improves maintainability, type safety, and configuration validation throughout the codebase.

- Replaced direct os.getenv() calls with typed Pydantic BaseSettings classes
- Introduced nested DatabaseConfig for database-specific settings and main Settings class
- Added singleton pattern with @lru_cache for efficient settings access across modules