### PR TITLE
fix(settings): remove unused get_psycopg_connection_string function

### DIFF
--- a/rag/config/settings.py
+++ b/rag/config/settings.py
@@ -66,8 +66,3 @@ class Settings(BaseSettings):
 def get_settings() -> Settings:
     """Get cached settings instance (singleton)."""
     return Settings()
-
-
-def get_psycopg_connection_string() -> str:
-    """Build psycopg3 connection string."""
-    return get_settings().database.conn_string


### PR DESCRIPTION
This PR removes an unused utility function get_psycopg_connection_string from the settings module to clean up dead code.

- Removes the get_psycopg_connection_string function that was building a psycopg3 connection string
